### PR TITLE
Change JSONHandler from returning empty optionals to default values

### DIFF
--- a/src/main/java/io/github/neopixel/Test.java
+++ b/src/main/java/io/github/neopixel/Test.java
@@ -1,0 +1,12 @@
+package io.github.neopixel;
+
+import io.github.neopixel.wrapper.player.HypixelPlayer;
+import java.util.UUID;
+
+public class Test {
+    public static void main(String[] args) {
+        HypixelAPI api = HypixelAPI.create(UUID.fromString("d8e7f0b1-6dcf-4a96-993c-8f11cf2fe15b"));
+        HypixelPlayer player = api.getPlayerByName("___");
+        System.out.println(player.getNetworkLevel());
+    }
+}

--- a/src/main/java/io/github/neopixel/wrapper/HypixelLootChestGame.java
+++ b/src/main/java/io/github/neopixel/wrapper/HypixelLootChestGame.java
@@ -4,13 +4,13 @@ import java.util.Optional;
 
 public interface HypixelLootChestGame {
 
-    Optional<Integer> getOpenedChestsAmount();
+    int getOpenedChestsAmount();
 
-    Optional<Integer> getOpenedCommonChestsAmount();
+    int getOpenedCommonChestsAmount();
 
-    Optional<Integer> getOpenedRareChestsAmount();
+    int getOpenedRareChestsAmount();
 
-    Optional<Integer> getOpenedEpicChestsAmount();
+    int getOpenedEpicChestsAmount();
 
-    Optional<Integer> getOpenedLegendaryChestsAmount();
+    int getOpenedLegendaryChestsAmount();
 }

--- a/src/main/java/io/github/neopixel/wrapper/games/HypixelCosmetic.java
+++ b/src/main/java/io/github/neopixel/wrapper/games/HypixelCosmetic.java
@@ -8,16 +8,16 @@ public interface HypixelCosmetic {
     public String getKey();
     public HypixelCosmeticRarities getRarity();
 
-    public static Optional<HypixelCosmetic> getHypixelCosmeticFromKey(
+    public static HypixelCosmetic getHypixelCosmeticFromKey(
         Class<? extends HypixelCosmetic> enumeration,
         String string) {
 
         for (Object e : enumeration.getEnumConstants()) {
             HypixelCosmetic cosmetic = (HypixelCosmetic) e;
             if (cosmetic.getKey().equals(string)) {
-                return Optional.of(cosmetic);
+                return cosmetic;
             }
         }
-        return Optional.empty();
+        return null;
     }
 }

--- a/src/main/java/io/github/neopixel/wrapper/games/bedwars/HypixelBedWars.java
+++ b/src/main/java/io/github/neopixel/wrapper/games/bedwars/HypixelBedWars.java
@@ -18,87 +18,87 @@ public class HypixelBedWars {
     /**
      * @return The amount of resources the player has collected.
      */
-    public Optional<Integer> getResourcesCollected() {
+    public int getResourcesCollected() {
         return jsonHandler.getSafeInt("resources_collected_bedwars");
     }
 
     /**
      * @return The amount of diamonds the player has collected.
      */
-    public Optional<Integer> getDiamondsCollected() {
+    public int getDiamondsCollected() {
         return jsonHandler.getSafeInt("diamond_resources_collected_bedwars");
     }
 
     /**
      * @return The amount of emeralds the player has collected.
      */
-    public Optional<Integer> getEmeraldsCollected() {
+    public int getEmeraldsCollected() {
         return jsonHandler.getSafeInt("emerald_resources_collected_bedwars");
     }
 
     /**
      * @return The amount of gold the player has collected.
      */
-    public Optional<Integer> getGoldCollected() {
+    public int getGoldCollected() {
         return jsonHandler.getSafeInt("gold_resources_collected_bedwars");
     }
 
     /**
      * @return The amount of iron the player has collected.
      */
-    public Optional<Integer> getIronCollected() {
+    public int getIronCollected() {
         return jsonHandler.getSafeInt("iron_resources_collected_bedwars");
     }
 
-    public Optional<Integer> getKills(BedWarsKillCause cause) {
+    public int getKills(BedWarsKillCause cause) {
         return jsonHandler.getSafeInt(cause.getKey() + "kills_bedwars");
     }
 
-    public Optional<Integer> getDeaths(BedWarsKillCause cause) {
+    public int getDeaths(BedWarsKillCause cause) {
         return jsonHandler.getSafeInt(cause.getKey() + "deaths_bedwars");
     }
 
-    public Optional<Integer> getKillToDeathRatio(BedWarsKillCause cause) {
-        return Optional.ofNullable(getKills(cause).get() / Math.max(getDeaths(cause).get(), 1));
+    public int getKillToDeathRatio(BedWarsKillCause cause) {
+        return getKills(cause) / Math.max(getDeaths(cause), 1);
     }
 
-    public Optional<Integer> getFinalKills(BedWarsKillCause cause) {
+    public int getFinalKills(BedWarsKillCause cause) {
         return jsonHandler.getSafeInt(cause.getKey() + "final_kills_bedwars");
     }
 
-    public Optional<Integer> getFinalDeaths(BedWarsKillCause cause) {
+    public int getFinalDeaths(BedWarsKillCause cause) {
         return jsonHandler.getSafeInt(cause.getKey() + "final_deaths_bedwars");
     }
 
-    public Optional<Integer> getFinalKillToDeathRatio(BedWarsKillCause cause) {
-        return Optional.ofNullable(getFinalKills(cause).get() / Math.max(getFinalDeaths(cause).get(), 1));
+    public int getFinalKillToDeathRatio(BedWarsKillCause cause) {
+        return getFinalKills(cause) / Math.max(getFinalDeaths(cause), 1);
     }
 
     /**
      * @return The amount of wins the player has.
      */
-    public Optional<Integer> getWins() {
+    public int getWins() {
         return jsonHandler.getSafeInt("wins_bedwars");
     }
 
     /**
      * @return The amount of losses the player has.
      */
-    public Optional<Integer> getLosses() {
+    public int getLosses() {
         return jsonHandler.getSafeInt("losses_bedwars");
     }
 
     /**
      * @return The player's win to loss ratio.
      */
-    public Optional<Integer> getWinToLossRatio() {
-        return Optional.ofNullable(getWins().get() / Math.max(getLosses().get(), 1));
+    public int getWinToLossRatio() {
+        return getWins() / Math.max(getLosses(), 1);
     }
 
     /**
      * @return The amount of beds the player has broken.
      */
-    public Optional<Integer> getBedsBroken() {
+    public int getBedsBroken() {
         return jsonHandler.getSafeInt("beds_broken_bedwars");
     }
 
@@ -106,21 +106,21 @@ public class HypixelBedWars {
      * @return The amount of items the player has purchased from the shop.
      */
 
-    public Optional<Integer> getItemsPurchasedAmount() {
+    public int getItemsPurchasedAmount() {
         return jsonHandler.getSafeInt("items_purchased_bedwars");
     }
 
     /**
      * @return The amount of games the player has played.
      */
-    public Optional<Integer> getGamesPlayed() {
+    public int getGamesPlayed() {
         return jsonHandler.getSafeInt("games_played_bedwars");
     }
 
     /**
      * @return The player's current winstreak.
      */
-    public Optional<Integer> getCurrentWinstreak() {
+    public int getCurrentWinstreak() {
         return jsonHandler.getSafeInt("winstreak");
     }
 

--- a/src/main/java/io/github/neopixel/wrapper/games/bedwars/HypixelBedWarsStats.java
+++ b/src/main/java/io/github/neopixel/wrapper/games/bedwars/HypixelBedWarsStats.java
@@ -55,7 +55,7 @@ public class HypixelBedWarsStats extends HypixelGame implements HypixelLootChest
      *
      * @return The total number of Bed Wars coins the player currently has.
      */
-    public final Optional<Integer> getCoins() {
+    public final int getCoins() {
         return jsonHandler.getSafeInt("coins");
     }
 
@@ -66,7 +66,7 @@ public class HypixelBedWarsStats extends HypixelGame implements HypixelLootChest
      *
      * @return The player's current Bed Wars level.
      */
-    public final Optional<Integer> getLevel() {
+    public final int getLevel() {
         return jsonHandler.getSafeInt("level");
     }
 
@@ -77,7 +77,7 @@ public class HypixelBedWarsStats extends HypixelGame implements HypixelLootChest
      *
      * @return The player's total Bed Wars experience.
      */
-    public final Optional<Integer> getExperience() {
+    public final int getExperience() {
         return jsonHandler.getSafeInt("Experience");
     }
 
@@ -88,8 +88,8 @@ public class HypixelBedWarsStats extends HypixelGame implements HypixelLootChest
      *
      * @return The ID of the effect played when the player wins.
      */
-    public final Optional<HypixelCosmetic> getActiveVictoryDance() {
-        return HypixelCosmetic.getHypixelCosmeticFromKey(BedwarsVictoryDances.class, jsonHandler.getSafeString("activeVictoryDance").get());
+    public final HypixelCosmetic getActiveVictoryDance() {
+        return HypixelCosmetic.getHypixelCosmeticFromKey(BedwarsVictoryDances.class, jsonHandler.getSafeString("activeVictoryDance"));
     }
 
     /**
@@ -99,8 +99,8 @@ public class HypixelBedWarsStats extends HypixelGame implements HypixelLootChest
      *
      * @return The ID of the player's selected island topper.
      */
-    public final Optional<HypixelCosmetic> getActiveIslandTopper() {
-        return HypixelCosmetic.getHypixelCosmeticFromKey(BedwarsIslandToppers.class, jsonHandler.getSafeString("activeIslandTopper").get());
+    public final HypixelCosmetic getActiveIslandTopper() {
+        return HypixelCosmetic.getHypixelCosmeticFromKey(BedwarsIslandToppers.class, jsonHandler.getSafeString("activeIslandTopper"));
     }
 
     /**
@@ -110,8 +110,8 @@ public class HypixelBedWarsStats extends HypixelGame implements HypixelLootChest
      *
      * @return The ID of the player's selected spray.
      */
-    public final Optional<HypixelCosmetic> getActiveSpray() {
-        return HypixelCosmetic.getHypixelCosmeticFromKey(BedwarsSprays.class, jsonHandler.getSafeString("activeSprays").get());
+    public final HypixelCosmetic getActiveSpray() {
+        return HypixelCosmetic.getHypixelCosmeticFromKey(BedwarsSprays.class, jsonHandler.getSafeString("activeSprays"));
     }
 
     /**
@@ -121,32 +121,32 @@ public class HypixelBedWarsStats extends HypixelGame implements HypixelLootChest
      *
      * @return The ID of the effect played when the player dies.
      */
-    public final Optional<HypixelCosmetic> getActiveDeathCry() {
-        return HypixelCosmetic.getHypixelCosmeticFromKey(BedwarsDeathCries.class, jsonHandler.getSafeString("activeDeathCry").get());
+    public final HypixelCosmetic getActiveDeathCry() {
+        return HypixelCosmetic.getHypixelCosmeticFromKey(BedwarsDeathCries.class, jsonHandler.getSafeString("activeDeathCry"));
     }
 
     @Override
-    public Optional<Integer> getOpenedChestsAmount() {
+    public int getOpenedChestsAmount() {
         return jsonHandler.getSafeInt("Bedwars_openedChests");
     }
 
     @Override
-    public Optional<Integer> getOpenedCommonChestsAmount() {
+    public int getOpenedCommonChestsAmount() {
         return jsonHandler.getSafeInt("Bedwars_openedCommons");
     }
 
     @Override
-    public Optional<Integer> getOpenedRareChestsAmount() {
+    public int getOpenedRareChestsAmount() {
         return jsonHandler.getSafeInt("Bedwars_openedRares");
     }
 
     @Override
-    public Optional<Integer> getOpenedEpicChestsAmount() {
+    public int getOpenedEpicChestsAmount() {
         return jsonHandler.getSafeInt("Bedwars_openedEpics");
     }
 
     @Override
-    public Optional<Integer> getOpenedLegendaryChestsAmount() {
+    public int getOpenedLegendaryChestsAmount() {
         return jsonHandler.getSafeInt("Bedwars_openedLegendaries");
     }
 }

--- a/src/main/java/io/github/neopixel/wrapper/games/build_battle/HypixelBuildBattle.java
+++ b/src/main/java/io/github/neopixel/wrapper/games/build_battle/HypixelBuildBattle.java
@@ -27,59 +27,59 @@ public class HypixelBuildBattle extends HypixelGame {
         return false;
     }
 
-    public Optional<Integer> getSoloWins() {
+    public int getSoloWins() {
         return jsonHandler.getSafeInt("wins_solo_normal");
     }
 
-    public Optional<Integer> getTeamWins() {
+    public int getTeamWins() {
         return jsonHandler.getSafeInt("wins_teams_normal");
     }
 
-    public Optional<Integer> getWins() {
+    public int getWins() {
         return jsonHandler.getSafeInt("wins");
     }
 
-    public Optional<Integer> getCoins() {
+    public int getCoins() {
         return jsonHandler.getSafeInt("coins");
     }
 
-    public Optional<Integer> getGuessTheBuildWins() {
+    public int getGuessTheBuildWins() {
         return jsonHandler.getSafeInt("wins_guess_the_build");
     }
 
-    public Optional<Integer> getGamesPlayed() {
+    public int getGamesPlayed() {
         return jsonHandler.getSafeInt("games_played");
     }
 
-    public Optional<Integer> getScore() {
+    public int getScore() {
         return jsonHandler.getSafeInt("score");
     }
 
-    public Optional<Integer> getMonthlyCoinsA() {
+    public int getMonthlyCoinsA() {
         return jsonHandler.getSafeInt("monthly_coins_a");
     }
 
-    public Optional<Integer> getWeeklyCoinsB() {
+    public int getWeeklyCoinsB() {
         return jsonHandler.getSafeInt("weekly_coins_b");
     }
 
-    public Optional<Integer> getCorrectGuesses() {
+    public int getCorrectGuesses() {
         return jsonHandler.getSafeInt("correct_guesses");
     }
 
-    public Optional<Integer> getSoloMostPoints() {
+    public int getSoloMostPoints() {
         return jsonHandler.getSafeInt("solo_most_points");
     }
 
-    public Optional<Integer> getWeeklyCoinsA() {
+    public int getWeeklyCoinsA() {
         return jsonHandler.getSafeInt("weekly_coins_a");
     }
 
-    public Optional<Integer> getTotalVotes() {
+    public int getTotalVotes() {
         return jsonHandler.getSafeInt("total_votes");
     }
 
-    public Optional<Integer> getSuperVotes() {
+    public int getSuperVotes() {
         return jsonHandler.getSafeInt("super_votes");
     }
 
@@ -92,10 +92,10 @@ public class HypixelBuildBattle extends HypixelGame {
     }
 
     public HypixelBuildBattlePackages getSelectedHat() {
-        return HypixelBuildBattlePackages.valueOf(jsonHandler.getSafeInt("new_selected_hat").get().toString().toUpperCase());
+        return HypixelBuildBattlePackages.valueOf(jsonHandler.getSafeString("new_selected_hat").toUpperCase());
     }
 
-    public Optional<Integer> getMonthlyCoinsB() {
+    public int getMonthlyCoinsB() {
         return jsonHandler.getSafeInt("monthly_coins_b");
     }
 }

--- a/src/main/java/io/github/neopixel/wrapper/games/duels/HypixelDuels.java
+++ b/src/main/java/io/github/neopixel/wrapper/games/duels/HypixelDuels.java
@@ -27,27 +27,27 @@ public class HypixelDuels extends HypixelGame implements HypixelLootChestGame {
     }
 
     @Override
-    public final Optional<Integer> getOpenedChestsAmount() {
+    public final int getOpenedChestsAmount() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public final Optional<Integer> getOpenedCommonChestsAmount() {
+    public final int getOpenedCommonChestsAmount() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public final Optional<Integer> getOpenedRareChestsAmount() {
+    public final int getOpenedRareChestsAmount() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public final Optional<Integer> getOpenedEpicChestsAmount() {
+    public final int getOpenedEpicChestsAmount() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public final Optional<Integer> getOpenedLegendaryChestsAmount() {
+    public final int getOpenedLegendaryChestsAmount() {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/io/github/neopixel/wrapper/games/skywars/HypixelSkyWars.java
+++ b/src/main/java/io/github/neopixel/wrapper/games/skywars/HypixelSkyWars.java
@@ -27,27 +27,27 @@ public class HypixelSkyWars extends HypixelGame implements HypixelLootChestGame 
     }
 
     @Override
-    public final Optional<Integer> getOpenedChestsAmount() {
+    public final int getOpenedChestsAmount() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public final Optional<Integer> getOpenedCommonChestsAmount() {
+    public final int getOpenedCommonChestsAmount() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public final Optional<Integer> getOpenedRareChestsAmount() {
+    public final int getOpenedRareChestsAmount() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public final Optional<Integer> getOpenedEpicChestsAmount() {
+    public final int getOpenedEpicChestsAmount() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public final Optional<Integer> getOpenedLegendaryChestsAmount() {
+    public final int getOpenedLegendaryChestsAmount() {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/io/github/neopixel/wrapper/player/HypixelPlayer.java
+++ b/src/main/java/io/github/neopixel/wrapper/player/HypixelPlayer.java
@@ -30,23 +30,23 @@ public class HypixelPlayer {
         this.jsonHandler = new JSONHandler(requestController.getPlayer(uuid).getJSONObject("player"));
     }
 
-    public Optional<String> getUsername() {
+    public String getUsername() {
         return jsonHandler.getSafeString("displayname");
     }
 
-    public Optional<UUID> getUUID() {
+    public UUID getUUID() {
         return jsonHandler.getSafeUUID("uuid");
     }
 
-    public Optional<Integer> getNetworkLevel() {
-        return Optional.of(LevelUtil.getFullNetworkLevel(jsonHandler.getSafeLong("networkExp").get()));
+    public int getNetworkLevel() {
+        return LevelUtil.getFullNetworkLevel(jsonHandler.getSafeLong("networkExp"));
     }
 
-    public Optional<Double> getNetworkEXP() {
+    public double getNetworkEXP() {
         return jsonHandler.getSafeDouble("networkExp");
     }
 
-    public Optional<Integer> getNetworkKarma() {
+    public int getNetworkKarma() {
         return jsonHandler.getSafeInt("karma");
     }
 
@@ -54,24 +54,23 @@ public class HypixelPlayer {
      * @return A double representing the percentage of how far a HypixelPlayer is through their
      * current Network Level.
      */
-    public Optional<Long> getNetworkLevelPercentage() {
-        return Optional.ofNullable(LevelUtil.getProgressExp(jsonHandler.getSafeLong("networkExp").get()));
+    public long getNetworkLevelPercentage() {
+        return LevelUtil.getProgressExp(jsonHandler.getSafeLong("networkExp"));
     }
 
     /**
      * @return A double representing the amount of EXP the HypixelPlayer has progressed into their
      * current Network Level.
      */
-    public Optional<Integer> getEXPIntoCurrentNetworkLevel() {
-        return Optional.ofNullable(LevelUtil.getExpPastLastEventLevel(jsonHandler.getSafeLong("networkExp").get()));
+    public int getEXPIntoCurrentNetworkLevel() {
+        return LevelUtil.getExpPastLastEventLevel(jsonHandler.getSafeLong("networkExp"));
     }
 
     /**
      * @return A double representing how much EXP is required to the next level.
      */
-    public Optional<Integer> getEXPToNextNetworkLevel() {
-        return Optional.ofNullable(
-            LevelUtil.getExpUntilNextEventLevel(jsonHandler.getSafeLong("networkExp").get()));
+    public int getEXPToNextNetworkLevel() {
+        return LevelUtil.getExpUntilNextEventLevel(jsonHandler.getSafeLong("networkExp"));
     }
 
 
@@ -86,7 +85,7 @@ public class HypixelPlayer {
      * {@link HypixelPlayer}'s on the users friend list.
      */
     public Set<HypixelFriend> getHypixelFriends(int limit) {
-        JSONArray friendsRecords = requestController.getPlayerFriends(getUUID().get())
+        JSONArray friendsRecords = requestController.getPlayerFriends(getUUID())
             .getJSONArray("records");
         Set<HypixelFriend> hypixelFriends = new HashSet<>();
 
@@ -120,7 +119,7 @@ public class HypixelPlayer {
 
     public Set<HypixelFriend> getHypixelFriends() {
         JSONArray friendsRecords =
-            requestController.getPlayerFriends(getUUID().get()).getJSONArray("records");
+            requestController.getPlayerFriends(getUUID()).getJSONArray("records");
         Set<HypixelFriend> hypixelFriends = new HashSet<>();
         friendsRecords.forEach(friendObject -> {
             JSONObject friendJSONObject = (JSONObject) friendObject;
@@ -151,37 +150,36 @@ public class HypixelPlayer {
     }
 
     public boolean isOnline() {
-        return requestController.getPlayerStatus(getUsername().get()).getJSONObject("session")
+        return requestController.getPlayerStatus(getUsername()).getJSONObject("session")
             .getBoolean("online");
     }
 
-    public Optional<Integer> getTotalDailyRewardsClaimed() {
+    public int getTotalDailyRewardsClaimed() {
         return jsonHandler.getSafeInt("totalDailyRewards");
     }
 
-    public Optional<Integer> getTopDailyRewardStreak() {
+    public int getTopDailyRewardStreak() {
         return jsonHandler.getSafeInt("rewardHighScore");
     }
 
-    public Optional<Integer> getCurrentDailyRewardStreak() {
+    public int getCurrentDailyRewardStreak() {
         return jsonHandler.getSafeInt("rewardStreak");
     }
     
-    public Optional<HypixelRank> getHypixelRank() {
-        return Optional.ofNullable(
-            HypixelRank.valueOf(jsonHandler.getSafeString("newPackageRank").get()));
+    public HypixelRank getHypixelRank() {
+        return HypixelRank.valueOf(jsonHandler.getSafeString("newPackageRank"));
     }
 
-    public Optional<HypixelColors> getHypixelRankPlusColor() {
-        return Optional.ofNullable(HypixelColors.valueOf(jsonHandler.getSafeString("rankPlusColor").get()));
+    public HypixelColors getHypixelRankPlusColor() {
+        return HypixelColors.valueOf(jsonHandler.getSafeString("rankPlusColor"));
     }
 
     public HypixelGuild getGuild() {
-        return new HypixelGuild(getUUID().get(), requestController);
+        return new HypixelGuild(getUUID(), requestController);
     }
 
     public HypixelPlayerGames getGames() {
         return Optional.ofNullable(games)
-            .orElse(games = new HypixelPlayerGames(jsonHandler.getJSONObject("stats").get()));
+            .orElse(games = new HypixelPlayerGames(jsonHandler.getJSONObject("stats")));
     }
 }

--- a/src/main/java/io/github/neopixel/wrapper/util/JSONHandler.java
+++ b/src/main/java/io/github/neopixel/wrapper/util/JSONHandler.java
@@ -20,53 +20,53 @@ public class JSONHandler {
         this.statsPrefix = statsPrefix;
     }
 
-    public Optional<String> getSafeString(String key) {
+    public String getSafeString(String key) {
         if (stats.has(statsPrefix + key)) {
-            return Optional.of(stats.getString(statsPrefix + key));
+            return stats.getString(statsPrefix + key);
         } else {
-            return Optional.empty();
+            return null;
         }
     }
 
-    public Optional<Integer> getSafeInt(String key) {
+    public int getSafeInt(String key) {
         if (stats.has(statsPrefix + key)) {
-            return Optional.of(stats.getInt(statsPrefix + key));
+          return stats.getInt(statsPrefix + key);
         } else {
-            return Optional.empty();
+            return 0;
         }
     }
 
-    public Optional<Double> getSafeDouble(String key) {
+    public double getSafeDouble(String key) {
         if (stats.has(statsPrefix + key)) {
-            return Optional.of(stats.getDouble(statsPrefix + key));
+            return stats.getDouble(statsPrefix + key);
         } else {
-            return Optional.empty();
+            return 0;
         }
     }
 
-    public Optional<Long> getSafeLong(String key) {
+    public long getSafeLong(String key) {
         if (stats.has(statsPrefix + key)) {
-            return Optional.of(stats.getLong(statsPrefix + key));
+            return stats.getLong(statsPrefix + key);
         } else {
-            return Optional.empty();
+            return 0;
         }
     }
 
-    public Optional<UUID> getSafeUUID(String key) {
+    public UUID getSafeUUID(String key) {
         if (stats.has(statsPrefix + key)) {
-            return Optional.of(UnformattedStringToUUID.convertUnformattedStringToUUID(
-                stats.getString(statsPrefix + key)));
+            return UnformattedStringToUUID.convertUnformattedStringToUUID(
+                getSafeString(key));
         } else {
-            return Optional.empty();
+            return null;
         }
 
     }
 
-    public Optional<JSONObject> getJSONObject(String key) {
+    public JSONObject getJSONObject(String key) {
         if (stats.has(key)) {
-            return Optional.of(stats.getJSONObject(key));
+            return stats.getJSONObject(key);
         } else {
-            return Optional.empty();
+            return null;
         }
     }
 


### PR DESCRIPTION
This commit will make the `JSONHandler` class return default values instead of empty `Optional`'s. It checks if the value is present, and if it is it returns the value, but if it isn't it returns a default value based on the type. The `JSONHandler` class is needed because if the value wasn't present in the API an `NPE` would be thrown. 

Originally, `Optional`'s were preferred because we were nervous about the User handling null values. But, after further consideration returning default values is preferable because in reality that is what the value really is. For example, if the User has no kills in lucky blocks bedwars that statistic wouldn't show up. But really, they just have the default value of 0.