### PR TITLE
getSafeString() return an empty String

### DIFF
--- a/src/main/java/io/github/neopixel/wrapper/util/JSONHandler.java
+++ b/src/main/java/io/github/neopixel/wrapper/util/JSONHandler.java
@@ -34,7 +34,7 @@ public class JSONHandler {
         if (stats.has(statsPrefix + key)) {
             return stats.getString(statsPrefix + key);
         } else {
-            return null;
+            return "";
         }
     }
 


### PR DESCRIPTION
This will lead to less NPE's.